### PR TITLE
Fix broken compile in issue #11 fix

### DIFF
--- a/sw3/src/com/noteflight/standingwave3/elements/Sample.as
+++ b/sw3/src/com/noteflight/standingwave3/elements/Sample.as
@@ -657,7 +657,7 @@ package com.noteflight.standingwave3.elements
 			thisSamplePointer = getSamplePointer(targetOffset); // mix in at this position
 			tableSamplePointer = source.getSamplePointer(0); // use the whole wavetable
 			numFrames = Math.min(numFrames, _frames - targetOffset); // don't mix more frames than are left in our target 
-        	var tableSize:Number = (source.frameCount - 1)*_source.descriptor.channels; // minus a guard sample for interpolation
+        	var tableSize:Number = (source.frameCount - 1)*source.descriptor.channels; // minus a guard sample for interpolation
         	var phase:Number = sourceOffset / source.frameCount; // phase = fractional progress through the source
         	var phaseAdd:Number = factor / source.frameCount;
         	var settings:Object = {tableSize:tableSize, phase:phase, phaseAdd:phaseAdd, phaseReset:0, y1:0, y2:0};


### PR DESCRIPTION
Thanks for responding so quickly. Your patch works, but you've written `_source` instead of `source`, which breaks the compile.
