### PR TITLE
Method readBytes

### DIFF
--- a/sw3/src/com/noteflight/standingwave3/elements/Sample.as
+++ b/sw3/src/com/noteflight/standingwave3/elements/Sample.as
@@ -93,7 +93,7 @@ package com.noteflight.standingwave3.elements
             if (samplePointer) {
             	this._samplePointer = samplePointer;
             } else {
-              this._samplePointer = _pool.fetch(len, zero ? 1 : 0);
+              this._samplePointer = _pool.fetch(len, zero ? true : false);
             }
             
             // If a pool-sourced buffer was not available, then allocate new memory
@@ -819,7 +819,11 @@ package com.noteflight.standingwave3.elements
           	}
             invalidateChannelData();
         }
-        
+		public function readBytes(bytes:ByteArray):void {
+			_awaveMemory.position = getSamplePointer();
+			_awaveMemory.writeBytes(bytes);
+			invalidateChannelData();
+		}
         
         /** 
          * Read the sample data out to another ByteArray.


### PR DESCRIPTION
I read that standingwave3 was developed before we were able to access the microphone bytes. That was a problem for me so I fixed it- which was easy as the microphone returns plain sample data just like a WAVE/RIFF file which is already included in the current SW3 source.

As the class Sample is final I had to directly modify the source to be able to read in samples collected from a microphone. Now there is no need to convert you mic samples first to a WAV format anymore.
Here a scenario which is possible now:

``` javascript
var BYTES_PER_SAMPLE:int= 4;
var CHANNELS:int = 2

/*
Get all samples collected from the microphone. Here a sample recorder class created by me.
IMPORTANT: ByteArray have to be set to flash.utils.Endian.LITTLE_ENDIAN;
*/
var bytes:ByteArray = _microphoneRecorder.getCircularBufferContent();

var sample:Sample=new Sample(new AudioDescriptor,bytes.length/(BYTES_PER_SAMPLE*CHANNELS));

// This is change, we are now able to read raw microphone
sample.readBytes(bytes); 

//Yeah, now play the mic input with all the cool magic you can do with Standingwave3
_audioPlayer.play(sample) 
```
