### PR TITLE
Bugfix for AudioPlayer stop()/play() bug

### DIFF
--- a/sw3/src/com/noteflight/standingwave3/output/AudioPlayer.as
+++ b/sw3/src/com/noteflight/standingwave3/output/AudioPlayer.as
@@ -106,6 +106,13 @@ package com.noteflight.standingwave3.output
                     _channel.soundTransform = new SoundTransform(0);
                     _channel = null;
                 }
+
+                if(_sound){
+                  /*This fixes an annoying bug. If you start and start the sample source again
+                  you will notice that the sound plays in multiple speed dependet on how often you started the same source again.
+                  It`s a bug! You have to remove the handler for sample data when erasing the _sound object. In general this also prevents memory leaking. */
+                  _sound.removeEventListener(SampleDataEvent.SAMPLE_DATA, handleSampleData);
+                }
                 _sound = null;
             }
         }


### PR DESCRIPTION
This fixes an annoying bug in AudioPlayer.
If you start and start the sample source over and over again you will notice that the sound plays in multiple speed dependent on how often you started the same source again. 

I found that "handleSampleData" is called once after the stop method was called. My first workaround was a cool down phase for the audio player instance of some milliseconds because I expected a somewhat complex reason hidden in the underlying alchemy byte array access code. And yeah, that helped for the moment.

Some days later I looked at the code again and found the real cause. So simple. An orphaned event listener. Look at the pull request for the exact position of the fix. Simply remove the handler from the sound object when erasing the _sound object. In general this also prevents memory leaking.

``` javascript
if(_sound){
  _sound.removeEventListener(SampleDataEvent.SAMPLE_DATA, handleSampleData);
}
_sound = null;
```
